### PR TITLE
Fix #3: Including Empty Array in Manifest

### DIFF
--- a/module/Public/Add-CommandToManifest.ps1
+++ b/module/Public/Add-CommandToManifest.ps1
@@ -35,7 +35,8 @@ function Add-CommandToManifest {
     function GetManifestField ([string]$Name) {
         $field = Find-Ast -First { $PSItem.Value -eq $Name } | Find-Ast -First
         # This transforms a literal string array expression into it's output without invoking.
-        $valueString = $field.ToString() -split   '[,\n\s]' `
+        $valueString = $field.ToString() -replace '@\(\)' `
+                                         -split   '[,\n\s]' `
                                          -replace '['',\s]' `
                                          -match   '.' `
                                          -as      [List[string]]


### PR DESCRIPTION
This change fixes an issue where adding the first command to a manifest using `Add-CommandToManifest` would add an empty array as an entry.