### PR TITLE
Fix markdown generation and module determination

### DIFF
--- a/module/Public/ConvertTo-MarkdownHelp.ps1
+++ b/module/Public/ConvertTo-MarkdownHelp.ps1
@@ -24,7 +24,10 @@ function ConvertTo-MarkdownHelp {
                 $docsPath,
                 $psEditor.Workspace.Path)
 
-            $onlineUri = $projectUri, $normalizedDocs, ($Ast.Name + '.md') -join '/' -replace '\\', '/'
+            $onlineUri = $projectUri,
+                         'blob/master',
+                         $normalizedDocs,
+                         ($Ast.Name + '.md') -join '/' -replace '\\', '/'
         }
 
         # Wrap this whole thing in a try/finally so we can dispose of temp files and PowerShell
@@ -84,6 +87,10 @@ function ConvertTo-MarkdownHelp {
         }
 
         Start-Sleep -Milliseconds 50
+
+        if (-not (Test-Path $docsPath)) {
+            $null = New-Item $docsPath -ItemType Directory
+        }
 
         $targetMarkdownPath = '{0}\{1}.md' -f $docsPath, $Ast.Name
         if (-not (Test-Path $targetMarkdownPath)) {


### PR DESCRIPTION
- Fixed an issue where `ConvertTo-MarkdownHelp` would not add `blob/master` to online help URI path. Closes #10 

- Fixed an issue where `ConvertTo-MarkdownHelp` would not create the docs folder if it did not already exist.  Closes #8 

- Fixed an issue where `Add-ModuleQualification` could not determine the module if the current workspace did not have a manifest. Closes #9 

- Fixed an issue where `Add-ModuleQualification` would insert the wrong module and command name if multiple versions of the same module were loaded into the current session.