### PR TITLE
Fix invalid struct signature

### DIFF
--- a/module/Public/Add-PinvokeMethod.ps1
+++ b/module/Public/Add-PinvokeMethod.ps1
@@ -200,7 +200,7 @@ function Add-PinvokeMethod {
         $signature = $signatureInfo.Signature `
             -split '\|' `
             -join [Environment]::NewLine `
-            -replace '(?<!public )(?:private )?(static|struct)', 'public $1' `
+            -replace '(?<!public )(?<!\[)(?:private )?(static|struct)', 'public $1' `
             -replace '\s+$' `
             -replace "'", "''"
 


### PR DESCRIPTION
- Fix an issue where the public keyword could be prepended to `StructLayout` attribute causing compilation errors.