### PR TITLE
Refactor Expand-MemberExpression Function

### DIFF
--- a/docs/en-US/EditorServicesCommandSuite.md
+++ b/docs/en-US/EditorServicesCommandSuite.md
@@ -52,7 +52,7 @@ The Expand-Expression function replaces text at a specified range with it's outp
 
 ### [Expand-MemberExpression](Expand-MemberExpression.md)
 
-The Expand-MemberExpression function creates an expression for the closest MemberExpressionAst to the cursor in the current editor context. This is mainly to assist with creating expressions to access private members of .NET classes through reflection.
+The Expand-MemberExpression function expands member expressions to a more explicit statement.
 
 ### [Expand-TypeImplementation](Expand-TypeImplementation.md)
 

--- a/module/Classes/MemberExpressionGeneration.ps1
+++ b/module/Classes/MemberExpressionGeneration.ps1
@@ -1,0 +1,251 @@
+using namespace System.Management.Automation
+using namespace System.Reflection
+using namespace System.Text
+
+class MemberExpressionGeneration {
+    static [string] $Indent = '    ';
+
+    [MemberInfo] $Member;
+    [psobject] $Target;
+    [bool] $BeVerbose;
+
+    hidden [bool] $WasVerbose;
+    hidden [StringBuilder] $Builder;
+    hidden [string] $Flags;
+    hidden [bool] $IsMethod;
+    hidden [bool] $IsConstructor;
+
+    hidden MemberExpressionGeneration([MemberInfo] $member, [psobject] $target) {
+        $this.Target = $target
+        $this.Member = $member
+        $this.IsMethod = $this.Member -is [MethodBase]
+        $this.IsConstructor = $this.Member -is [ConstructorInfo]
+        $this.Flags = "[System.Reflection.BindingFlags]'{0}'" -f (
+            [MemberExpressionGeneration]::GetBindingFlags(
+                $this.Member))
+
+        $this.Builder = [StringBuilder]::new()
+        $this.Builder.psobject.Methods.Add(
+            [PSCodeMethod]::new(
+                'AppendInvocationArgs',
+                [MemberExpressionGeneration].GetMethod('InvocationArgsCodeMethod')))
+
+        $this.Builder.psobject.Methods.Add(
+            [PSCodeMethod]::new(
+                'AppendParameterName',
+                [MemberExpressionGeneration].GetMethod('CommentCodeMethod')))
+
+        $this.Builder.psobject.Methods.Add(
+            [PSCodeMethod]::new(
+                'AppendIndent',
+                [MemberExpressionGeneration].GetMethod('IndentCodeMethod')))
+    }
+
+    static [string] GetReflectionExpression([psobject] $instance, [MemberInfo] $member) {
+        return [MemberExpressionGeneration]::GetReflectionExpression(
+            $instance,
+            $member,
+            $false)
+    }
+
+    static [string] GetReflectionExpression(
+        [psobject] $instance,
+        [MemberInfo] $member,
+        [bool] $beVerbose)
+    {
+        $helper = [MemberExpressionGeneration]::new($member, $instance)
+        $helper.BeVerbose = $beVerbose
+        return $helper.GetExpression()
+    }
+
+    static [string[]] GetInvocationArgs([ParameterInfo[]] $parameters) {
+        return [MemberExpressionGeneration]::GetInvocationArgs($parameters, $true)
+    }
+
+    static [string[]] GetInvocationArgs([ParameterInfo[]] $parameters, [bool] $includeNameComments) {
+        $result = foreach ($parameter in $parameters) {
+            $comment = ''
+            if ($includeNameComments) {
+                $comment = '<# {0}: #> ' -f $parameter.Name
+            }
+
+            '{0}${1}' -f $comment, $parameter.Name
+        }
+
+        return $result
+    }
+
+    hidden static [StringBuilder] InvocationArgsCodeMethod(
+        [psobject] $instance,
+        [int] $indent,
+        [MemberInfo] $member)
+    {
+        $parameters = $member.GetParameters()
+        if (-not $parameters.Count) {
+            return $instance
+        }
+
+        $indentText = (@([MemberExpressionGeneration]::Indent) * $indent) -join ''
+
+        if ($parameters.Count) {
+            $instance.AppendLine().Append($indentText)
+        }
+
+        return $instance.Append(
+            [MemberExpressionGeneration]::GetInvocationArgs($parameters) -join (
+                ',' + [Environment]::NewLine + $indentText))
+    }
+
+    static hidden [StringBuilder] CommentCodeMethod([psobject] $instance, [string] $parameterName) {
+        return $instance.AppendFormat('<# {0}: #> ', $parameterName)
+    }
+
+    static hidden [StringBuilder] IndentCodeMethod([psobject] $instance) {
+        return $instance.Append([MemberExpressionGeneration]::Indent)
+    }
+
+    static hidden [BindingFlags] GetBindingFlags([MemberInfo] $member) {
+        $scope = [BindingFlags]::Instance
+        if ([MemberExpressionGeneration]::IsStatic($member)) {
+            $scope = [BindingFlags]::Static
+        }
+
+        return [BindingFlags]::NonPublic -bor $scope
+    }
+
+    static hidden [bool] IsStatic([MemberInfo] $member) {
+        if ($member -is [PropertyInfo]) {
+            return $member.GetMethod.IsStatic
+        }
+
+        return $member.IsStatic
+    }
+
+    [string] GetExpression() {
+        $this.WriteBridge()
+        $this.WriteGetArgs()
+        $this.WriteInvocationExpression()
+
+        return $this.Builder.ToString()
+    }
+
+    hidden [void] WriteBridge() {
+        $this.Builder.
+            Append($this.GetSourceExpression()).
+            AppendLine('.').
+            AppendIndent().
+            Append('Get').
+            Append($this.Member.MemberType).
+            Append('(')
+    }
+
+    hidden [void] WriteGetArgs() {
+        $canBeVerbose = -not ([MemberTypes]'Property, Field').HasFlag($this.Member.MemberType)
+        if ($this.BeVerbose -and $canBeVerbose ) {
+            $this.WriteComplexGetArgs()
+            return
+        }
+
+        $this.WriteBasicGetArgs()
+    }
+
+    hidden [void] WriteInvocationExpression() {
+        $methodName = 'GetValue'
+        if ($this.IsMethod) {
+            $methodName = 'Invoke'
+        }
+
+        $this.Builder.AppendLine().AppendIndent().
+            Append($methodName).Append('(')
+
+        if (-not $this.IsConstructor) {
+            $this.Builder.Append($this.GetTargetExpression())
+
+            if (-not $this.IsMethod) {
+                $this.Builder.Append(')')
+                return
+            }
+
+            $this.Builder.Append(', ')
+        }
+
+        $this.Builder.
+            Append('@(').
+            AppendInvocationArgs(2, $this.Member).
+            Append('))')
+    }
+
+    hidden [string] GetSourceExpression() {
+        if ($this.IsConstructor) {
+            if ($this.Target -isnot [type]) {
+                $this.Target = $this.Member.ReflectedType
+            }
+
+            return [TypeExpressionHelper]::Create($this.Target)
+        }
+
+        if ($this.Target -is [type]) {
+            return [TypeExpressionHelper]::Create($this.Target)
+        }
+
+        return $this.Target.ToString() + '.GetType()'
+    }
+
+    hidden [string] GetTargetExpression() {
+        if ($this.IsConstructor) {
+            return [string]::Empty
+        }
+
+        if ([MemberExpressionGeneration]::IsStatic($this.Member)) {
+            return '$null'
+        }
+
+        if ($this.Target -is [type]) {
+            return '$instance'
+        }
+
+        return $this.Target.ToString()
+    }
+
+    hidden [void] WriteBasicGetArgs() {
+        $this.
+            Builder.
+            AppendFormat("'{0}', ", $this.Member.Name).
+            Append($this.Flags).
+            Append(").")
+    }
+
+    hidden [void] WriteComplexGetArgs() {
+        if ($this.Member -isnot [ConstructorInfo]) {
+            $this.Builder.AppendLine().AppendIndent().AppendIndent().
+                AppendParameterName('name').
+                AppendFormat("'{0}',", $this.Member.Name)
+        }
+
+        $this.Builder.AppendLine().AppendIndent().AppendIndent().
+            AppendParameterName('bindingAttr').
+            Append($this.Flags).
+            Append(',')
+
+        $this.Builder.AppendLine().AppendIndent().AppendIndent().
+            AppendParameterName('binder').
+            Append('$null,')
+
+        $types = foreach($parameter in $this.Member.GetParameters()) {
+            [TypeExpressionHelper]::Create($parameter.ParameterType)
+        }
+        $this.Builder.AppendLine().AppendIndent().AppendIndent().
+            AppendParameterName('types').
+            AppendFormat('@({0}),', $types -join ', ')
+
+        $modifiers = [int]($this.Member.GetParameters().Count)
+        if (-not $modifiers) {
+            $modifiers = '@()'
+        }
+
+        $this.Builder.AppendLine().AppendIndent().AppendIndent().
+            AppendParameterName('modifiers').
+            Append($modifiers).
+            Append(').')
+    }
+}

--- a/module/Classes/TextOps.ps1
+++ b/module/Classes/TextOps.ps1
@@ -1,0 +1,34 @@
+
+enum CaseType {
+    Pascal;
+    Camel;
+}
+
+class TextOps {
+    static [string] TransformCase([psobject] $text, [CaseType] $type) {
+        $methodName = 'ToUpperInvariant'
+        if ($type -eq [CaseType]::Camel) {
+            $methodName = 'ToLowerInvariant'
+        }
+
+        $asString = $text -as [string]
+        if ([string]::IsNullOrWhiteSpace($asString)) {
+            return [string]::Empty
+        }
+
+        if ($asString.Length -le 2) {
+            return $asString.$methodName()
+        }
+
+        return $asString.Substring(0, 1).$methodName() +
+                ($asString[1..$asString.Length] -join '')
+    }
+
+    static [string] ToCamelCase([psobject] $text) {
+        return [TextOps]::TransformCase($text, [CaseType]::Camel)
+    }
+
+    static [string] ToPascalCase([psobject] $text) {
+        return [TextOps]::TransformCase($text, [CaseType]::Pascal)
+    }
+}

--- a/module/EditorServicesCommandSuite.psm1
+++ b/module/EditorServicesCommandSuite.psm1
@@ -19,14 +19,9 @@ if (-not ('Antlr4.StringTemplate.StringRenderer' -as [type])) {
     Add-Type -Path $psstPath\Antlr4.StringTemplate.dll
 }
 
-. $PSScriptRoot\Classes\Expressions.ps1
-. $PSScriptRoot\Classes\Renderers.ps1
-. $PSScriptRoot\Classes\Async.ps1
-. $PSScriptRoot\Classes\Utility.ps1
-
-Get-ChildItem $PSScriptRoot\Public, $PSScriptRoot\Private -Filter '*.ps1' | ForEach-Object {
-    . $PSItem.FullName
-}
+"$PSScriptRoot\Classes", "$PSScriptRoot\Public", "$PSScriptRoot\Private" |
+    Get-ChildItem -Filter '*.ps1' |
+    ForEach-Object { . $PSItem.FullName }
 
 # Export only the functions using PowerShell standard verb-noun naming.
 # Be sure to list each exported functions in the FunctionsToExport field of the module manifest file.

--- a/module/Private/GetAncestorOrThrow.ps1
+++ b/module/Private/GetAncestorOrThrow.ps1
@@ -11,7 +11,10 @@ function GetAncestorOrThrow {
         $AstTypeName,
 
         [System.Management.Automation.PSCmdlet]
-        $ErrorContext
+        $ErrorContext,
+
+        [switch]
+        $ShowOnThrow
     )
     end {
         $astType = $AstTypeName -as [type]
@@ -30,6 +33,7 @@ function GetAncestorOrThrow {
             Target    = $Ast
             Category  = 'InvalidArgument'
             Id        = 'MissingAst'
+            Show      = $ShowOnThrow.IsPresent
         }
         if ($ErrorContext) { $throwErrorSplat.ErrorContext = $ErrorContext }
         ThrowError @throwErrorSplat

--- a/module/Private/GetInferredMember.ps1
+++ b/module/Private/GetInferredMember.ps1
@@ -36,10 +36,6 @@ function GetInferredMember {
         $Ast
     )
     process {
-        # If the ast that was passed is our ExtendedMemberExpressionAst class then return the already
-        # inferred member info.
-        if ($Ast.InferredMember) { return $Ast.InferredMember }
-
         $type = GetInferredType -Ast $Ast.Expression
 
         # Predicate to use with FindMembers.
@@ -69,8 +65,6 @@ function GetInferredMember {
                 if ($PSItem -is [MethodBase]) { $PSItem.GetParameters().Count }
                 else { 0 }
             }}
-
-        if ($member.Count -gt 1) { $member = $member[0] }
 
         if (-not $member) {
             ThrowError -Exception ([MissingMemberException]::new($Ast.Expression, $Ast.Member.Value)) `

--- a/module/Public/ConvertTo-FunctionDefinition.ps1
+++ b/module/Public/ConvertTo-FunctionDefinition.ps1
@@ -134,20 +134,6 @@ function ConvertTo-FunctionDefinition {
                        -Show
         }
 
-        # Safely captialize the first character if a string. If the string is two or less characters
-        # then capitialize the whole string.
-        function ToPascalCase {
-            param([string] $String)
-            end {
-                if ($String.Length -le 2) {
-                    return $String.ToUpperInvariant()
-                }
-
-                return $String.Substring(0, 1).ToUpperInvariant() +
-                       ($String[1..$String.Length] -join '')
-            }
-        }
-
         # Compile a dictionary of unique variables that should be parameters, along with their
         # inferred type if possible.
         function GetInferredParameters {
@@ -161,7 +147,7 @@ function ConvertTo-FunctionDefinition {
                 }
 
                 foreach ($variable in $Variables) {
-                    $asPascalCase = ToPascalCase $variable.VariablePath.UserPath
+                    $asPascalCase = [TextOps]::ToPascalCase($variable.VariablePath.UserPath)
 
                     $existingParameter = $null
                     if ($parameters.TryGetValue($asPascalCase, [ref]$existingParameter)) {
@@ -302,7 +288,7 @@ function ConvertTo-FunctionDefinition {
                     $targetStartOffset = $targetExtent.StartOffset
                     foreach ($expression in $variableExpressions) {
                         $variableName = $expression.VariablePath.UserPath
-                        $asPascalCase = ToPascalCase $variableName
+                        $asPascalCase = [TextOps]::ToPascalCase($variableName)
                         $variableOffset = $expression.Extent.StartOffset - $targetStartOffset
 
                         # Account for escaped variabled names (e.g ${my strange var name})


### PR DESCRIPTION
This change refactors `Expand-MemberExpression` significantly.

- **Breaking Change** - Remove `TemplateName` and `NoParameterNameComments` parameters

- Remove the overly complicated logic for targeting a specific overload and replace it with a QuickOpen choice prompt

- Change expression generation to use `StringBuilder` instead of `PSStringTemplate`. This is the first step in removing the dependency.

- Improve logic for determining the `Type.Get*` overload required to resolve a non-public member

- Fix a variety of scenarios where invalid expressions would be generated

- Fix an issue where detection of shortest resolvable type name would use the `TypeResolutionScope`, resulting in invalid type expressions