### PR TITLE
Better error handling in untitled workspaces and internal functions

### DIFF
--- a/module/Private/GetAncestorOrThrow.ps1
+++ b/module/Private/GetAncestorOrThrow.ps1
@@ -2,7 +2,6 @@ using namespace System.Management.Automation.Language
 
 function GetAncestorOrThrow {
     [OutputType([System.Management.Automation.Language.Ast])]
-    [CmdletBinding()]
     param(
         [System.Management.Automation.Language.Ast]
         $Ast,

--- a/module/Private/GetInferredManifest.ps1
+++ b/module/Private/GetInferredManifest.ps1
@@ -1,16 +1,30 @@
 using namespace Microsoft.PowerShell.EditorServices.Extensions
+using namespace System.Management.Automation
 
 function GetInferredManifest {
     [CmdletBinding()]
     param()
     end {
         $manifestPath = ResolveRelativePath (GetSettings).SourceManifestPath
-        if (-not $manifestPath -or -not (Test-Path $manifestPath)) {
-            ThrowError -Exception ([IO.InvalidDataException]::new($Strings.InvalidManifestSetting)) `
-                       -Id        InvalidManifestSetting `
-                       -Category  InvalidDataException `
-                       -Target    $manifestPath
+
+        if ([string]::IsNullOrWhiteSpace($manifestPath)) {
+            throw [ErrorRecord]::new(
+                <# exception:     #> [PSInvalidOperationException]::new($Strings.MissingWorkspaceManifest),
+                <# errorId:       #> 'MissingWorkspaceManifest',
+                <# errorCategory: #> 'InvalidOperation',
+                <# targetObject:  #> $manifestPath)
         }
+
+        if (-not (Test-Path $manifestPath)) {
+            $exception = [IO.InvalidDataException]::new(
+                $Strings.InvalidSettingValue -f 'SourceManifestPath')
+            throw [ErrorRecord]::new(
+                <# exception:     #> $exception,
+                <# errorId:       #> 'InvalidSettingValue',
+                <# errorCategory: #> 'InvalidData',
+                <# targetObject:  #> $manifestPath)
+        }
+
         $data = Import-LocalizedData -BaseDirectory (Split-Path $manifestPath) `
                                      -FileName      (Split-Path -Leaf $manifestPath)
         $null = $data.Add('Name', ((Split-Path $manifestPath -Leaf) -replace '.psd1$'))

--- a/module/Private/GetInferredMember.ps1
+++ b/module/Private/GetInferredMember.ps1
@@ -38,41 +38,21 @@ function GetInferredMember {
     process {
         $type = GetInferredType -Ast $Ast.Expression
 
-        # Predicate to use with FindMembers.
-        $predicate = {
-            param($Member, $Criteria)
-
-            $nameFilter, $argCountFilter = $Criteria
-
-            $Member.Name -eq $nameFilter -and
-            (-not $argCountFilter -or $Member.GetParameters().Count -eq $argCountFilter)
-        }
-        # Check if it looks like the argument count was specified explicitly.
-        $argumentCount     = $Ast.Arguments.Count
-        if ($Ast.Arguments.Count -eq 1 -and $Ast.Arguments.StaticType -eq ([int])) {
-            $argumentCount = $Ast.Arguments.Value
-        }
         $member = $type.FindMembers(
             <# memberType:     #> 'All',
             <# bindingAttr:    #> [BindingFlags]'NonPublic, Public, Instance, Static, IgnoreCase',
-            <# filter:         #> $predicate,
-            <# filterCriteria: #> @(($Ast.Member.Value -replace '^new$', '.ctor'), $argumentCount)
+            <# filter:         #> { param($member, $criteria) $member.Name -eq $criteria },
+            <# filterCriteria: #> ($Ast.Member.Value -replace '^new$', '.ctor'))
 
-            # Prioritize properties over fields and methods with smaller parameter counts.
-        ) | Sort-Object -Property `
-            @{Expression = { $PSItem.MemberType }; Ascending = $false },
-            @{Expression = {
-                if ($PSItem -is [MethodBase]) { $PSItem.GetParameters().Count }
-                else { 0 }
-            }}
-
-        if (-not $member) {
-            ThrowError -Exception ([MissingMemberException]::new($Ast.Expression, $Ast.Member.Value)) `
-                       -Id        MissingMember `
-                       -Category  InvalidResult `
-                       -Target    $Ast
+        if ($member) {
+            return $member
         }
 
-        $member
+        $exception = [System.MissingMemberException]::new($Ast.Expression, $Ast.Member.Value)
+        throw [System.Management.Automation.ErrorRecord]::new(
+            <# exception:     #> $exception,
+            <# errorId:       #> 'MissingMember',
+            <# errorCategory: #> 'InvalidResult',
+            <# targetObject:  #> $Ast)
     }
 }

--- a/module/Private/GetInferredMember.ps1
+++ b/module/Private/GetInferredMember.ps1
@@ -36,7 +36,15 @@ function GetInferredMember {
         $Ast
     )
     process {
-        $type = GetInferredType -Ast $Ast.Expression
+        try {
+            $type = GetInferredType -Ast $Ast.Expression
+        } catch {
+            throw [System.Management.Automation.ErrorRecord]::new(
+                <# exception:     #> $exception,
+                <# errorId:       #> 'MissingMember',
+                <# errorCategory: #> 'InvalidResult',
+                <# targetObject:  #> $Ast)
+        }
 
         $member = $type.FindMembers(
             <# memberType:     #> 'All',

--- a/module/Private/GetInferredType.ps1
+++ b/module/Private/GetInferredType.ps1
@@ -101,7 +101,13 @@ function GetInferredType {
 
             if ($Ast -is [System.Management.Automation.Language.MemberExpressionAst]) {
                 $PSCmdlet.WriteDebug('TYPEINF: Starting member inference')
-                if ($member = GetInferredMember -Ast $Ast) {
+                try {
+                    $member = GetInferredMember -Ast $Ast
+                } catch [MissingMemberException] {
+                    $PSCmdlet.WriteDebug("Couldn't find member for AST $Ast")
+                }
+
+                if ($member) {
                     return (
                         $member.ReturnType,
                         $member.PropertyType,

--- a/module/Private/GetInferredType.ps1
+++ b/module/Private/GetInferredType.ps1
@@ -125,14 +125,14 @@ function GetInferredType {
                 }
 
                 if ($inferredManifest) {
-                $moduleVariable = Get-Module |
-                    Where-Object Guid -eq $inferredManifest.GUID |
-                    ForEach-Object { $PSItem.SessionState.PSVariable.GetValue($Ast.VariablePath.UserPath) } |
-                    Where-Object { $null -ne $PSItem }
+                    $moduleVariable = Get-Module |
+                        Where-Object Guid -eq $inferredManifest.GUID |
+                        ForEach-Object { $PSItem.SessionState.PSVariable.GetValue($Ast.VariablePath.UserPath) } |
+                        Where-Object { $null -ne $PSItem }
 
-                if ($moduleVariable) {
-                    return $moduleVariable.Where({ $null -ne $PSItem }, 'First')[0].GetType()
-                }
+                    if ($moduleVariable) {
+                        return $moduleVariable.Where({ $null -ne $PSItem }, 'First')[0].GetType()
+                    }
                 }
 
 
@@ -157,14 +157,17 @@ function GetInferredType {
     }
     end {
         $type = GetInferredTypeImpl
-        if (-not $type) {
-            ThrowError -Exception ([InvalidOperationException]::new($Strings.CannotInferType -f $Ast)) `
-                       -Id        CannotInferType `
-                       -Category  InvalidOperation `
-                       -Target    $Ast
-            return
+        if ($type) {
+            return $type
         }
 
-        $type
+        $exception = [System.Management.Automation.PSInvalidOperationException]::new(
+            $Strings.CannotInferType -f $Ast)
+
+        throw [System.Management.Automation.ErrorRecord]::new(
+            <# exception:     #> $exception,
+            <# errorId:       #> 'CannotInferType',
+            <# errorCategory: #> 'InvalidOperation',
+            <# targetObject:  #> $Ast)
     }
 }

--- a/module/Private/GetInferredType.ps1
+++ b/module/Private/GetInferredType.ps1
@@ -112,7 +112,13 @@ function GetInferredType {
 
             if ($Ast -is [System.Management.Automation.Language.VariableExpressionAst]) {
                 $PSCmdlet.WriteDebug('TYPEINF: Starting module state inference')
-                $inferredManifest = GetInferredManifest -ErrorAction Ignore
+                try {
+                    $inferredManifest = GetInferredManifest
+                } catch {
+                    $PSCmdlet.WriteVerbose($Strings.VerboseInvalidManifest)
+                }
+
+                if ($inferredManifest) {
                 $moduleVariable = Get-Module |
                     Where-Object Guid -eq $inferredManifest.GUID |
                     ForEach-Object { $PSItem.SessionState.PSVariable.GetValue($Ast.VariablePath.UserPath) } |
@@ -121,14 +127,22 @@ function GetInferredType {
                 if ($moduleVariable) {
                     return $moduleVariable.Where({ $null -ne $PSItem }, 'First')[0].GetType()
                 }
+                }
+
 
                 $PSCmdlet.WriteDebug('TYPEINF: Starting global state inference')
 
-                $foundInGlobal = $ExecutionContext.
-                    SessionState.
-                    Module.
-                    GetVariableFromCallersModule(
-                        $Ast.VariablePath.UserPath)
+                # I'd rather this use Module.GetVariableFromCallersModule but it appears to throw
+                # when a frame in the call stack doesn't have a session state, like the scriptblock
+                # of a editor command in some cases.
+                $getVariableSplat = @{
+                    Scope       = 'Global'
+                    Name        = $Ast.VariablePath.UserPath
+                    ErrorAction = 'Ignore'
+                }
+
+                $foundInGlobal = Get-Variable @getVariableSplat
+
                 if ($foundInGlobal -and $null -ne $foundInGlobal.Value) {
                     return $foundInGlobal.Value.GetType()
                 }

--- a/module/Private/GetSettings.ps1
+++ b/module/Private/GetSettings.ps1
@@ -5,13 +5,18 @@ function GetSettings {
         function GetHashtable {
             if ($script:CSSettings) { return $script:CSSettings }
 
-            $targetPath = Join-Path $psEditor.Workspace.Path -ChildPath 'ESCSSettings.psd1'
+            if (-not [string]::IsNullOrWhiteSpace($psEditor.Workspace.Path)) {
+                $targetPath = Join-Path $psEditor.Workspace.Path -ChildPath 'ESCSSettings.psd1'
 
-            if (Test-Path $targetPath) {
-                $script:CSSettings = Import-LocalizedData -BaseDirectory $psEditor.Workspace.Path `
-                                                        -FileName 'ESCSSettings.psd1'
+                if (Test-Path $targetPath) {
+                    $importLocalizedDataSplat = @{
+                        BaseDirectory = $psEditor.Workspace.Path
+                        FileName      = 'ESCSSettings.psd1'
+                    }
 
-                return $script:CSSettings
+                    $script:CSSettings = Import-LocalizedData @importLocalizedDataSplat
+                    return $script:CSSettings
+                }
             }
 
             $script:CSSettings = $script:DEFAULT_SETTINGS

--- a/module/Private/ResolveRelativePath.ps1
+++ b/module/Private/ResolveRelativePath.ps1
@@ -6,6 +6,10 @@ function ResolveRelativePath {
         function GetTargetPath {
             param()
             end {
+                if ([System.IO.Path]::IsPathRooted($Path)) {
+                    return $Path
+                }
+
                 $basePath = $psEditor.Workspace.Path
                 if ([string]::IsNullOrWhiteSpace($basePath)) {
                     $basePath = $PWD.Path
@@ -20,11 +24,15 @@ function ResolveRelativePath {
         }
     }
     end {
-        $targetPath = GetTargetPath -Path $Path
+        $targetPath = GetTargetPath
         if (-not $PSCmdlet.SessionState.Path.IsProviderQualified($targetPath)) {
             $targetPath = 'Microsoft.PowerShell.Core\FileSystem::' + $targetPath
         }
 
-        return $PSCmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath($targetPath)
+        try {
+            return $PSCmdlet.SessionState.Path.GetResolvedProviderPathFromPSPath($targetPath, [ref]$null)
+        } catch {
+            return $PSCmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath($targetPath)
+        }
     }
 }

--- a/module/Private/SetEditorLocation.ps1
+++ b/module/Private/SetEditorLocation.ps1
@@ -3,6 +3,17 @@ function SetEditorLocation {
     param([string]$Path)
     end {
         $resolved = ResolveRelativePath $Path
+
+        if (-not (Test-Path $resolved)) {
+            $exception = [System.Management.Automation.ItemNotFoundException]::new(
+                [Microsoft.PowerShell.Commands.UtilityResources]::PathDoesNotExist -f $resolved)
+            throw [System.Management.Automation.ErrorRecord]::new(
+                <# exception:     #> $exception,
+                <# errorId:       #> 'PathNotFound',
+                <# errorCategory: #> 'ObjectNotFound',
+                <# targetObject:  #> $resolved)
+        }
+
         $psEditor.Workspace.OpenFile($resolved)
 
         WaitUntil { $psEditor.GetEditorContext().CurrentFile.Path -eq $resolved.Path }

--- a/module/Private/ThrowError.ps1
+++ b/module/Private/ThrowError.ps1
@@ -36,12 +36,6 @@ function ThrowError {
         $Show
     )
     end {
-        # Need to manually check error action because of calling the error methods from a different
-        # cmdlet context. Also reading/setting the error preference variable when the value is "Ignore"
-        # throws, so we get it through variable intrinsics.
-        $errorPreference = $ExecutionContext.SessionState.PSVariable.GetValue('ErrorActionPreference')
-        if ($errorPreference -eq 'Ignore') { return }
-
         if (-not $ErrorContext) {
             foreach ($frame in (Get-PSCallStack)) {
                 if ($frame.Command -eq $MyInvocation.MyCommand.Name) { continue }
@@ -49,6 +43,12 @@ function ThrowError {
             }
             if (-not $ErrorContext) { $ErrorContext = $PSCmdlet }
         }
+
+        $errorPreference = $ErrorContext.SessionState.PSVariable.GetValue('ErrorActionPreference')
+        if ($errorPreference -eq 'Ignore') {
+            return
+        }
+
         if ($PSCmdlet.ParameterSetName -eq 'New') {
             $ErrorRecord = [ErrorRecord]::new($Exception, $Id, $Category, $TargetObject)
         }

--- a/module/Public/Add-CommandToManifest.ps1
+++ b/module/Public/Add-CommandToManifest.ps1
@@ -9,55 +9,87 @@ function Add-CommandToManifest {
     [CmdletBinding()]
     [EditorCommand(DisplayName='Add Closest Function To Manifest')]
     param()
+    begin {
+        function AssertRequiredSetting {
+            param([string] $SettingName)
+            end {
+                if (-not [string]::IsNullOrWhiteSpace($settings.$SettingName)) {
+                    return
+                }
 
-    $commandAst = Find-Ast -AtCursor |
-        Find-Ast -Ancestor -First -IncludeStartingAst { $PSItem.Name -and $PSItem.Name -match '\w+-\w+'}
+                $exception = [System.Management.Automation.PSArgumentException]::new(
+                    $Strings.InvalidSettingValue -f $SettingName)
+                $throwErrorSplat = @{
+                    Exception = $exception
+                    Category  = 'InvalidArgument'
+                    Id        = 'InvalidSettingValue'
+                    Target    = $settings
+                    Show      = $true
+                }
 
-    $settings     = GetSettings
-    $functionName = $commandAst.Name
-    $filePath     = $psEditor.GetEditorContext().CurrentFile.Path
+                ThrowError @throwErrorSplat
+            }
+        }
+    }
 
-    try {
+    end {
+        $commandAst = Find-Ast -AtCursor |
+            Find-Ast -Ancestor -First -IncludeStartingAst { $PSItem.Name -and $PSItem.Name -match '\w+-\w+'}
+
+        $settings     = GetSettings
+        $functionName = $commandAst.Name
+        $filePath     = $psEditor.GetEditorContext().CurrentFile.Path
+
+        AssertRequiredSetting -SettingName MainModuleDirectory
+        AssertRequiredSetting -SettingName SourceManifestPath
         $fileListEntry = $PSCmdlet.SessionState.Path.NormalizeRelativePath(
             $filePath,
             (ResolveRelativePath $settings.MainModuleDirectory))
 
         $manifestFile = ResolveRelativePath $settings.SourceManifestPath
-    } catch {
-        ThrowError -Exception ([ArgumentException]::new($Strings.InvalidSettingValue -f 'SourceManifestPath')) `
-                   -Id        InvalidSettingValue `
-                   -Category  InvalidArgument `
-                   -Target    $settings
-    }
 
-    SetEditorLocation $manifestFile
+        try {
+            SetEditorLocation $manifestFile
+        } catch {
+            $exception = [System.Management.Automation.PSArgumentException]::new(
+                $Strings.InvalidSettingValue -f 'SourceManifestPath')
+            $throwErrorSplat = @{
+                Exception = $exception
+                Category  = 'InvalidArgument'
+                Id        = 'InvalidSettingValue'
+                Target    = $settings
+                Show      = $true
+            }
 
-    function GetManifestField ([string]$Name) {
-        $field = Find-Ast -First { $PSItem.Value -eq $Name } | Find-Ast -First
-        # This transforms a literal string array expression into it's output without invoking.
-        $valueString = $field.ToString() -replace '@\(\)' `
-                                         -split   '[,\n\s]' `
-                                         -replace '['',\s]' `
-                                         -match   '.' `
-                                         -as      [List[string]]
-        # yield
-        [PSCustomObject]@{
-            Ast    = $field
-            Extent = $field.Extent
-            Value  = $valueString
+            ThrowError @throwErrorSplat
+            return
         }
+
+        function GetManifestField ([string]$Name) {
+            $field = Find-Ast -First { $PSItem.Value -eq $Name } | Find-Ast -First
+            # This transforms a literal string array expression into it's output without invoking.
+            $valueString = $field.ToString() -replace '@\(\)' `
+                                             -split   '[,\n\s]' `
+                                             -replace '['',\s]' `
+                                             -match   '.' `
+                                             -as      [List[string]]
+            # yield
+            [PSCustomObject]@{
+                Ast    = $field
+                Extent = $field.Extent
+                Value  = $valueString
+            }
+        }
+
+        $functions = GetManifestField -Name FunctionsToExport
+        $functions.Value.Add($functionName)
+        $functions.Value.Sort({ $args[0].CompareTo($args[1]) })
+        $functions.Extent | Set-ScriptExtent -Text ([Enumerable]::Distinct($functions.Value)) -AsArray
+
+        $fileList = GetManifestField -Name FileList
+
+        $fileList.Value.Add($fileListEntry)
+        $fileList.Value.Sort({ $args[0].CompareTo($args[1]) })
+        $fileList.Extent | Set-ScriptExtent -Text ([Enumerable]::Distinct($fileList.Value)) -AsArray
     }
-
-    $functions = GetManifestField -Name FunctionsToExport
-    $functions.Value.Add($functionName)
-    $functions.Value.Sort({ $args[0].CompareTo($args[1]) })
-    $functions.Extent | Set-ScriptExtent -Text ([Enumerable]::Distinct($functions.Value)) -AsArray
-
-    $fileList = GetManifestField -Name FileList
-
-    $fileList.Value.Add($fileListEntry)
-    $fileList.Value.Sort({ $args[0].CompareTo($args[1]) })
-    $fileList.Extent | Set-ScriptExtent -Text ([Enumerable]::Distinct($fileList.Value)) -AsArray
-
-    #SetEditorLocation $filePath
 }

--- a/module/Public/ConvertTo-FunctionDefinition.ps1
+++ b/module/Public/ConvertTo-FunctionDefinition.ps1
@@ -155,7 +155,12 @@ function ConvertTo-FunctionDefinition {
                             continue
                         }
 
-                        $inferredType = GetInferredType -Ast $variable -ErrorAction Ignore
+                        try {
+                            $inferredType = GetInferredType -Ast $variable
+                        } catch {
+                            $inferredType = [object]
+                        }
+
                         if ($inferredType -ne [object]) {
                             $parameters[$asPascalCase] = [Tuple[string, string, type, bool]]::new(
                                 $asPascalCase,
@@ -167,8 +172,9 @@ function ConvertTo-FunctionDefinition {
                         continue
                     }
 
-                    $inferredType = GetInferredType -Ast $variable -ErrorAction Ignore
-                    if (-not $inferredType) {
+                    try {
+                        $inferredType = GetInferredType -Ast $variable
+                    } catch {
                         $inferredType = [object]
                     }
 

--- a/module/Public/ConvertTo-LocalizationString.ps1
+++ b/module/Public/ConvertTo-LocalizationString.ps1
@@ -38,11 +38,15 @@ function ConvertTo-LocalizationString {
 
         try {
             SetEditorLocation (ResolveRelativePath (GetSettings).StringLocalizationManifest)
-        } catch {
-            ThrowError -Exception ([ArgumentException]::new($Strings.InvalidSettingValue -f 'StringLocalizationManifest')) `
-                       -Id         `
-                       -Category   `
-                       -Target     $null
+        } catch [System.Management.Automation.ItemNotFoundException] {
+            $exception = [System.Management.Automation.PSArgumentException]::new(
+                $Strings.InvalidSettingValue -f 'StringLocalizationManifest')
+            ThrowError -Exception  $exception `
+                       -Id         InvalidSettingValue`
+                       -Category   ObjectNotFound`
+                       -Target     $null `
+                       -Show
+            return
         }
 
         $hereString = Find-Ast { 'SingleQuotedHereString' -eq $_.StringConstantType } -First

--- a/module/Public/ConvertTo-MarkdownHelp.ps1
+++ b/module/Public/ConvertTo-MarkdownHelp.ps1
@@ -15,7 +15,13 @@ function ConvertTo-MarkdownHelp {
         $Ast = GetAncestorOrThrow $Ast -AstTypeName FunctionDefinitionAst -ErrorContext $PSCmdlet
 
         $settings = GetSettings
+        try {
         $manifest = GetInferredManifest
+        } catch {
+            ThrowError -ErrorRecord $PSItem -Show
+            return
+        }
+
         $docsPath = Join-Path (ResolveRelativePath $settings.MarkdownDocsPath) $PSCulture
         # If project uri is defined in the manifest then take a guess at what the online uri
         # should be.

--- a/module/Public/ConvertTo-MarkdownHelp.ps1
+++ b/module/Public/ConvertTo-MarkdownHelp.ps1
@@ -16,7 +16,7 @@ function ConvertTo-MarkdownHelp {
 
         $settings = GetSettings
         try {
-        $manifest = GetInferredManifest
+            $manifest = GetInferredManifest
         } catch {
             ThrowError -ErrorRecord $PSItem -Show
             return
@@ -76,6 +76,7 @@ function ConvertTo-MarkdownHelp {
                        -Category  InvalidOperation `
                        -Target    $markdownContent `
                        -Show
+            return
         }
 
         $helpToken = $ast | Get-Token |
@@ -103,7 +104,12 @@ function ConvertTo-MarkdownHelp {
             $null = New-Item $targetMarkdownPath -ItemType File
         }
 
-        SetEditorLocation $targetMarkdownPath
+        try {
+            SetEditorLocation $targetMarkdownPath
+        } catch [System.Management.Automation.ItemNotFoundException] {
+            ThrowError -ErrorRecord $PSItem -Show
+            return
+        }
 
         # Shape markdown according to linting rules.
         $markdownContent = $markdownContent -replace

--- a/module/Public/Expand-MemberExpression.ps1
+++ b/module/Public/Expand-MemberExpression.ps1
@@ -149,7 +149,7 @@ function Expand-MemberExpression {
             param([Ast] $Ast)
             end {
                 try {
-                $members = GetInferredMember -Ast $Ast
+                    $members = GetInferredMember -Ast $Ast
                 } catch {
                     ThrowError -ErrorRecord $PSItem -Show
                 }

--- a/module/Public/Expand-MemberExpression.ps1
+++ b/module/Public/Expand-MemberExpression.ps1
@@ -148,7 +148,11 @@ function Expand-MemberExpression {
         function GetTargetMember {
             param([Ast] $Ast)
             end {
+                try {
                 $members = GetInferredMember -Ast $Ast
+                } catch {
+                    ThrowError -ErrorRecord $PSItem -Show
+                }
 
                 if ($members.Count -le 1) {
                     return $members

--- a/module/Public/New-ESCSSettingsFile.ps1
+++ b/module/Public/New-ESCSSettingsFile.ps1
@@ -59,11 +59,16 @@ function New-ESCSSettingsFile {
                        -Id        TemplateGroupCompileError `
                        -Category  InvalidOperation `
                        -Target    $groupDefinition
+            return
         }
 
         $null = New-Item $targetFilePath -Value $content
         if ($psEditor) {
-            SetEditorLocation $targetFilePath
+            try {
+                SetEditorLocation $targetFilePath
+            } catch [System.Management.Automation.ItemNotFoundException] {
+                ThrowError -ErrorRecord $PSItem -Show
+            }
         }
     }
 }

--- a/module/en-US/Strings.psd1
+++ b/module/en-US/Strings.psd1
@@ -46,4 +46,7 @@ ExportFunctionInlineDescription=Directly above the target extent.
 ExportFunctionExternalFileDescription=In an existing or new file.
 ExportFunctionNamePrompt=Name the new function
 MissingFunctionName=You must specify a function name.
+ShouldCreateResourceFilePrompt=Unable to find the localization file for this workspace. What would you like to do?
+ShouldCreateResourceFileYes=Create localization file
+ShouldCreateResourceFileNo=Cancel changes
 '@

--- a/module/en-US/Strings.psd1
+++ b/module/en-US/Strings.psd1
@@ -28,6 +28,7 @@ TemplateGroupCompileError=Internal module error: Unable to compile default templ
 FailureGettingMarkdown=Unable to generate markdown content. Ensure you have the module PlatyPS installed and the comment based help is formatted correctly.
 SettingsFileExists=The settings file for workspace '{0}' already exists.
 InvalidSettingValue=The value of the setting '{0}' is invalid.  If you have not already created a settings file for this workspace, you can create one with the 'New-ESCSSettingsFile' function.
+MissingWorkspaceManifest=Unable to determine the module manifest file for this workspace.  If you have not already created a settings file for this workspace, you can create one with the 'New-ESCSSettingsFile' function.
 VerboseInvalidManifest=Unable to retrieve module manifest for current workspace.
 CannotInferModule=Unable to infer module information for the selected command.
 CommandNotInModule=The selected command does not belong to a module.


### PR DESCRIPTION
- Fix meaningless errors that sometimes occur in untitled workspaces

- Change internal function error handling to `throw` error records instead of using the `PSCmdlet.ThrowTerminatingError` method.  These error records will then be handled and rethrown by the caller with `PSCmdlet.ThrowTerminatingError`.  This is to resolve some issues around errors being thrown in the wrong context.

- `ConvertTo-LocalizationString` now prompts to create the resource file if it doesn't exist yet