### PR TITLE
Add Optional Custom Variable Name to ConvertTo-SplatExpression

### DIFF
--- a/docs/en-US/ConvertTo-SplatExpression.md
+++ b/docs/en-US/ConvertTo-SplatExpression.md
@@ -13,7 +13,7 @@ Convert a command expression to use splatting.
 ## SYNTAX
 
 ```powershell
-ConvertTo-SplatExpression [[-Ast] <Ast>]
+ConvertTo-SplatExpression [[-Ast] <Ast>] [[-VariableName] <String>]
 ```
 
 ## DESCRIPTION
@@ -56,6 +56,22 @@ Aliases:
 Required: False
 Position: 1
 Default value: (Find-Ast -AtCursor)
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VariableName
+
+Specifies the Varabile name to use for the splat hashtable variable.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: none
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/Public/ConvertTo-SplatExpression.ps1
+++ b/module/Public/ConvertTo-SplatExpression.ps1
@@ -66,8 +66,8 @@ function ConvertTo-SplatExpression {
             $splat.($parameter.Key) = $parameter.Value.Value
         }
 
-        # Remove the hypen, change to camelCase and add 'Splat'
         if (-not $VariableName) {
+            # Remove the hypen, change to camelCase and add 'Splat'
             $variableName = [regex]::Replace(
                 ($commandName.Extent.Text -replace '-'),
                 '^[A-Z]',

--- a/module/Public/ConvertTo-SplatExpression.ps1
+++ b/module/Public/ConvertTo-SplatExpression.ps1
@@ -11,6 +11,9 @@ function ConvertTo-SplatExpression {
     param(
         [System.Management.Automation.Language.Ast]
         $Ast
+        
+        [String]
+        $VariableName
     )
     begin {
         function ConvertFromExpressionAst($expression) {
@@ -64,11 +67,13 @@ function ConvertTo-SplatExpression {
         }
 
         # Remove the hypen, change to camelCase and add 'Splat'
-        $variableName = [regex]::Replace(
-            ($commandName.Extent.Text -replace '-'),
-            '^[A-Z]',
-            { $args[0].Value.ToLower() }) +
-            'Splat'
+        if (-not $VariableName) {
+            $variableName = [regex]::Replace(
+                ($commandName.Extent.Text -replace '-'),
+                '^[A-Z]',
+                { $args[0].Value.ToLower() }) +
+                'Splat'
+        }
 
         $sb = [System.Text.StringBuilder]::
             new('${0}' -f $variableName).

--- a/module/Public/ConvertTo-SplatExpression.ps1
+++ b/module/Public/ConvertTo-SplatExpression.ps1
@@ -10,7 +10,7 @@ function ConvertTo-SplatExpression {
     [EditorCommand(DisplayName='Convert Command to Splat Expression')]
     param(
         [System.Management.Automation.Language.Ast]
-        $Ast
+        $Ast,
         
         [String]
         $VariableName


### PR DESCRIPTION
I like to standardize on `$Param` in 99.999% of cases. So I figured this was a good compromise. I could probably set this in my `$PSDefaultParameterValues` then.