### PR TITLE
Add refactor to format method invocation arguments

### DIFF
--- a/src/EditorServicesCommandSuite/CodeGeneration/Refactors/FormatMethodArgumentsRefactor.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/Refactors/FormatMethodArgumentsRefactor.cs
@@ -1,0 +1,191 @@
+using System.Collections.Immutable;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using System.Threading.Tasks;
+
+using EditorServicesCommandSuite.Internal;
+using EditorServicesCommandSuite.Language;
+
+namespace EditorServicesCommandSuite.CodeGeneration.Refactors
+{
+    [Refactor(VerbsCommon.Set, "ArgumentListFormat")]
+    internal sealed class FormatMethodArgumentsRefactor : RefactorProvider
+    {
+        public override ImmutableArray<CodeAction> SupportedActions { get; } =
+            ImmutableArray.Create(
+                CodeAction.Inactive(
+                    CodeActionIds.FormatMethodArguments,
+                    FormatMethodArgumentsStrings.FormatSeparateLines),
+                CodeAction.Inactive(
+                    CodeActionIds.FormatMethodArguments,
+                    FormatMethodArgumentsStrings.FormatSingleLine));
+
+        private CodeAction SeparateLinesAction => SupportedActions[0];
+
+        private CodeAction SingleLineAction => SupportedActions[1];
+
+        public override async Task ComputeCodeActions(DocumentContextBase context)
+        {
+            if (!context.Ast.TryFindParent(maxDepth: 3, out InvokeMemberExpressionAst invokeMember))
+            {
+                return;
+            }
+
+            if (invokeMember.Arguments.Count <= 1)
+            {
+                return;
+            }
+
+            bool allSameLine = true;
+            int syncLine = invokeMember.Member.Extent.EndLineNumber;
+            foreach (ExpressionAst argument in invokeMember.Arguments)
+            {
+                if (argument.Extent.StartLineNumber != syncLine)
+                {
+                    allSameLine = false;
+                    break;
+                }
+            }
+
+            if (allSameLine)
+            {
+                await context.RegisterCodeActionAsync(
+                    SeparateLinesAction.With(FormatSeparateLines, invokeMember))
+                    .ConfigureAwait(false);
+                return;
+            }
+
+            await context.RegisterCodeActionAsync(
+                SingleLineAction.With(FormatSingleLine, invokeMember))
+                .ConfigureAwait(false);
+        }
+
+        private static async Task FormatSingleLine(
+            DocumentContextBase context,
+            InvokeMemberExpressionAst invokeMember)
+        {
+            var writer = new PowerShellScriptWriter(invokeMember);
+            TokenNode lparenToken = context.Token.List.First.FindNextOrSelf()
+                .ContainingOrAfterEndOf(invokeMember.Member)
+                .IncludeSelf().OfKind(TokenKind.LParen)
+                .GetResult();
+
+            TokenFinder finder = lparenToken.FindNext().OnlyWithin(invokeMember);
+            bool isFirstNewLine = true;
+            while (finder.OfKind(TokenKind.NewLine).TryGetResult(out TokenNode newLineNode))
+            {
+                bool isInArgument = false;
+                foreach (ExpressionAst argument in invokeMember.Arguments)
+                {
+                    if (argument.Extent.ContainsExtent(newLineNode.Value.Extent))
+                    {
+                        isInArgument = true;
+                        break;
+                    }
+                }
+
+                if (isInArgument)
+                {
+                    continue;
+                }
+
+                if (newLineNode.Value.Extent.IsAfter(invokeMember.Extent))
+                {
+                    break;
+                }
+
+                if (!newLineNode.TryGetNext(out TokenNode nodeAfterNewLine))
+                {
+                    continue;
+                }
+
+                writer.StartWriting(
+                    newLineNode.Value.Extent.StartOffset,
+                    nodeAfterNewLine.Value.Extent.StartOffset);
+
+                if (isFirstNewLine)
+                {
+                    writer.Write(string.Empty);
+                    isFirstNewLine = false;
+                }
+                else
+                {
+                    writer.Write(Symbols.Space);
+                }
+
+                writer.FinishWriting();
+            }
+
+            await context.RegisterWorkspaceChangeAsync(
+                WorkspaceChange.EditDocument(context.Document, writer.Edits))
+                .ConfigureAwait(false);
+        }
+
+        private static async Task FormatSeparateLines(
+            DocumentContextBase context,
+            InvokeMemberExpressionAst invokeMember)
+        {
+            TokenNode lparenToken = context.Token.List.First.FindNext()
+                .ContainingOrAfterEndOf(invokeMember.Member)
+                .IncludeSelf().OfKind(TokenKind.LParen)
+                .GetResult();
+
+            var writer = new PowerShellScriptWriter(context);
+            int lastLine = lparenToken.Value.Extent.EndLineNumber;
+            int argCount = invokeMember.Arguments.Count;
+            for (int i = 0; i < argCount; i++)
+            {
+                ExpressionAst arg = invokeMember.Arguments[i];
+                if (arg.Extent.StartLineNumber == lastLine)
+                {
+                    writer.StartWriting(arg.Extent.StartOffset);
+                    writer.PushIndent();
+                    writer.WriteLine();
+                    writer.WriteIndentIfPending();
+                    writer.FinishWriting();
+
+                    if (i == argCount - 1)
+                    {
+                        // Shouldn't be anything to trim if this is the last argument.
+                        continue;
+                    }
+
+                    TokenNode separator = lparenToken
+                        .FindNext()
+                        .OnlyWithin(invokeMember)
+                        .ContainingEndOf(arg)
+                        .Then().IncludeSelf().OfKind(TokenKind.Comma)
+                        .GetResult();
+
+                    Token tokenAfter = separator.Next.Value;
+                    if (separator.Value.Extent.StartLineNumber != tokenAfter.Extent.StartLineNumber)
+                    {
+                        // Don't try to trim line if there was already a line break between this
+                        // argument and the next.
+                        continue;
+                    }
+
+                    int positionDifference = tokenAfter.Extent.StartOffset - separator.Value.Extent.EndOffset;
+                    if (positionDifference == 0)
+                    {
+                        // Nothing to trim if the separator is right next to the next token.
+                        continue;
+                    }
+
+                    writer.StartWriting(
+                        separator.Value.Extent.EndOffset,
+                        tokenAfter.Extent.StartOffset);
+
+                    writer.Write(string.Empty);
+                    writer.FinishWriting();
+                }
+
+                lastLine = arg.Extent.EndLineNumber;
+            }
+
+            await context.RegisterWorkspaceChangeAsync(
+                WorkspaceChange.EditDocument(context.Document, writer.Edits))
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/EditorServicesCommandSuite/Internal/CommandSuite.cs
+++ b/src/EditorServicesCommandSuite/Internal/CommandSuite.cs
@@ -4,6 +4,7 @@ using System.Management.Automation;
 using System.Management.Automation.Host;
 using System.Threading;
 using System.Threading.Tasks;
+
 using EditorServicesCommandSuite.CodeGeneration;
 using EditorServicesCommandSuite.CodeGeneration.Refactors;
 using EditorServicesCommandSuite.Utility;
@@ -199,6 +200,7 @@ namespace EditorServicesCommandSuite.Internal
             Refactors.RegisterProvider(new ExtractFunctionRefactor(UI, Workspace));
             Refactors.RegisterProvider(new NameUnnamedBlockRefactor());
             Refactors.RegisterProvider(new RegisterCommandExportRefactor(Workspace));
+            Refactors.RegisterProvider(new FormatMethodArgumentsRefactor());
         }
 
         internal async Task ProcessWorkspaceChanges(WorkspaceChange[] changes, CancellationToken cancellationToken = default)

--- a/src/EditorServicesCommandSuite/resources/FormatMethodArgumentsStrings.resx
+++ b/src/EditorServicesCommandSuite/resources/FormatMethodArgumentsStrings.resx
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FormatSeparateLines" xml:space="preserve">
+    <value>Format arguments on separate lines.</value>
+  </data>
+  <data name="FormatSingleLine" xml:space="preserve">
+    <value>Format arguments on a single line.</value>
+  </data>
+</root>


### PR DESCRIPTION
Adds a refactor that formats method arguments. If all arguments are on the same line, the refactor will put every argument on it's own line.  If all arguments are on separate lines, the refactor will put every argument onto the same line.