### PR TITLE
Load ESCS in PSES's load context when in PSCore

### DIFF
--- a/EditorServicesCommandSuite.build.ps1
+++ b/EditorServicesCommandSuite.build.ps1
@@ -69,9 +69,9 @@ task AssertPowerShellCore {
     }
 
     if ($Force.IsPresent) {
-        choco install powershell-core --version 6.1.1 -y
+        choco install powershell-core --version 6.2.3 -y
     } else {
-        choco install powershell-core --verison 6.1.1
+        choco install powershell-core --verison 6.2.3
     }
 
     $script:pwsh = Get-Command $env:ProgramFiles/PowerShell/6/pwsh.exe @FailOnError

--- a/module/EditorServicesCommandSuite.psm1
+++ b/module/EditorServicesCommandSuite.psm1
@@ -3,9 +3,20 @@ Import-Module $PSScriptRoot/EditorServicesCommandSuite.RefactorCmdlets.cdxml
 Update-FormatData -AppendPath $PSScriptRoot/EditorServicesCommandSuite.format.ps1xml
 
 if ($null -ne $psEditor) {
-    Add-Type -Path "$PSScriptRoot/EditorServicesCommandSuite.EditorServices.dll"
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $psesLoadContext = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(
+            [Microsoft.PowerShell.EditorServices.Services.PowerShellContext.EditorObject].Assembly)
 
-    $CommandSuite = [EditorServicesCommandSuite.EditorServices.Internal.CommandSuite]::GetCommandSuite(
+        $assembly = $psesLoadContext.LoadFromAssemblyPath((
+            Join-Path $PSScriptRoot -ChildPath 'EditorServicesCommandSuite.EditorServices.dll'))
+
+        $type = $assembly.GetType('EditorServicesCommandSuite.EditorServices.Internal.CommandSuite')
+    } else {
+        Add-Type -Path "$PSScriptRoot/EditorServicesCommandSuite.EditorServices.dll"
+        $type = [EditorServicesCommandSuite.EditorServices.Internal.CommandSuite]
+    }
+
+    $CommandSuite = $type::GetCommandSuite(
         $psEditor,
         $ExecutionContext,
         $Host)

--- a/src/EditorServicesCommandSuite/EditorServicesCommandSuite.csproj
+++ b/src/EditorServicesCommandSuite/EditorServicesCommandSuite.csproj
@@ -3,7 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.14.0" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.14.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/tools/AssertPSES.ps1
+++ b/tools/AssertPSES.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [ValidateNotNull()]
-    [string] $RequiredVersion = '2.0.0-preview.6'
+    [string] $RequiredVersion = '2.0.0-preview.8'
 )
 begin {
     Add-Type -AssemblyName System.IO.Compression
@@ -49,7 +49,7 @@ end {
     $oldSecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol
     try {
         [System.Net.ServicePointManager]::SecurityProtocol = 'Tls, Tls11, Tls12'
-        $downloadUri = "https://github.com/PowerShell/PowerShellEditorServices/releases/download/v$version/PowerShellEditorServices.zip"
+        $downloadUri = "https://github.com/PowerShell/PowerShellEditorServices/releases/download/$version/PowerShellEditorServices.zip"
         Invoke-WebRequest -UseBasicParsing -Uri $downloadUri -OutFile $psesFolder/PowerShellEditorServices.zip
     } finally {
         [System.Net.ServicePointManager]::SecurityProtocol = $oldSecurityProtocol


### PR DESCRIPTION
PowerShellEditorServices made some changes to how it handles it's own assemblies.  In PowerShell Core it uses `AssemblyLoadContext`s to separate it's dependencies from the rest of the process.  We need those dependencies (and cannot load our own copies as they'll load as separate assemblies and cause JIT time exceptions etc) so we load ourselves into PSES's custom load context.