### PR TITLE
Fix for PSES 2.0 GA in PS7

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.csharp",
+        "ms-dotnettools.csharp",
         "ms-vscode.powershell",
         "DavidAnson.vscode-markdownlint",
     ],

--- a/EditorServicesCommandSuite.build.ps1
+++ b/EditorServicesCommandSuite.build.ps1
@@ -79,7 +79,7 @@ task AssertPowerShellCore {
 
 task AssertRequiredModules {
     $assertRequiredModule = Get-Command $ToolsPath/AssertRequiredModule.ps1 @FailOnError
-    & $assertRequiredModule platyPS -RequiredVersion 0.12.0 -Force:$Force.IsPresent
+    & $assertRequiredModule platyPS -RequiredVersion 0.14.0 -Force:$Force.IsPresent
 }
 
 task AssertDotNet {

--- a/EditorServicesCommandSuite.build.ps1
+++ b/EditorServicesCommandSuite.build.ps1
@@ -69,12 +69,12 @@ task AssertPowerShellCore {
     }
 
     if ($Force.IsPresent) {
-        choco install powershell-core --version 6.2.3 -y
+        choco install powershell-core --version 7.0.0 -y
     } else {
-        choco install powershell-core --verison 6.2.3
+        choco install powershell-core --verison 7.0.0
     }
 
-    $script:pwsh = Get-Command $env:ProgramFiles/PowerShell/6/pwsh.exe @FailOnError
+    $script:pwsh = Get-Command $env:ProgramFiles/PowerShell/7/pwsh.exe @FailOnError
 }
 
 task AssertRequiredModules {

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,7 @@ param(
     [switch] $Force
 )
 end {
-    & "$PSScriptRoot\tools\AssertRequiredModule.ps1" InvokeBuild 5.4.2 -Force:$Force.IsPresent
+    & "$PSScriptRoot\tools\AssertRequiredModule.ps1" InvokeBuild 5.5.6 -Force:$Force.IsPresent
     $invokeBuildSplat = @{
         Task = 'PrePublish'
         File = "$PSScriptRoot/EditorServicesCommandSuite.build.ps1"

--- a/module/EditorServicesCommandSuite.psd1
+++ b/module/EditorServicesCommandSuite.psd1
@@ -12,7 +12,7 @@
 RootModule = 'EditorServicesCommandSuite.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.5.0'
+ModuleVersion = '1.0.0'
 
 # ID used to uniquely identify this module
 GUID = '97607afd-d9bd-4a2e-a9f9-70fe1a0a9e4c'
@@ -69,30 +69,6 @@ VariablesToExport = @()
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
 AliasesToExport = 'Add-CommandToManifest'
 
-# List of all files packaged with this module
-FileList = 'en-US\EditorServicesCommandSuite-help.xml',
-           'EditorServicesCommandSuite.Classes.ps1',
-           'EditorServicesCommandSuite.deps.json',
-           'EditorServicesCommandSuite.dll',
-           'EditorServicesCommandSuite.EditorServices.deps.json',
-           'EditorServicesCommandSuite.EditorServices.dll',
-           'EditorServicesCommandSuite.EditorServices.pdb',
-           'EditorServicesCommandSuite.EditorServices.xml',
-           'EditorServicesCommandSuite.format.ps1xml',
-           'EditorServicesCommandSuite.pdb',
-           'EditorServicesCommandSuite.psd1',
-           'EditorServicesCommandSuite.psm1',
-           'EditorServicesCommandSuite.PSReadLine.deps.json',
-           'EditorServicesCommandSuite.PSReadLine.dll',
-           'EditorServicesCommandSuite.PSReadLine.pdb',
-           'EditorServicesCommandSuite.PSReadLine.xml',
-           'EditorServicesCommandSuite.RefactorCmdlets.cdxml',
-           'EditorServicesCommandSuite.xml',
-           'System.Buffers.dll',
-           'System.Memory.dll',
-           'System.Numerics.Vectors.dll',
-           'System.Runtime.CompilerServices.Unsafe.dll'
-
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
 
@@ -114,6 +90,9 @@ PrivateData = @{
         ReleaseNotes = @'
 - New editor command ConvertTo-FunctionDefinition for generating functions from selected text.
 '@
+
+        # Prerelease string of this module
+        Prerelease = 'beta1'
 
     } # End of PSData hashtable
 

--- a/module/EditorServicesCommandSuite.psm1
+++ b/module/EditorServicesCommandSuite.psm1
@@ -4,7 +4,7 @@ Update-FormatData -AppendPath $PSScriptRoot/EditorServicesCommandSuite.format.ps
 
 if ($null -ne $psEditor) {
     if ($PSVersionTable.PSVersion.Major -ge 6) {
-        $extensionService = [Microsoft.PowerShell.EditorServices.Extensions.EditorObjectExtensions]::
+        $extensionService = [Microsoft.PowerShell.EditorServices.Extensions.EditorObjectExtensions, Microsoft.PowerShell.EditorServices]::
             GetExtensionServiceProvider($psEditor)
 
         $assembly = $extensionService.LoadAssemblyInPsesLoadContext((

--- a/src/EditorServicesCommandSuite.Common.props
+++ b/src/EditorServicesCommandSuite.Common.props
@@ -7,6 +7,7 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <LangVersion>preview</LangVersion>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\EditorServicesCommandSuite\stylecop.json" />

--- a/src/EditorServicesCommandSuite/CodeGeneration/PowerShellScriptWriter.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/PowerShellScriptWriter.cs
@@ -143,11 +143,23 @@ namespace EditorServicesCommandSuite.CodeGeneration
                 SetPosition(0);
             }
 
-            Write(UsingUtilities.GetUsingStatementString(usings));
-
-            if (!existing.Any())
+            var oldPendingIndent = _pendingIndent;
+            var oldIndent = Indent;
+            try
             {
-                WriteLines(2);
+                _pendingIndent = null;
+                Indent = 0;
+                Write(UsingUtilities.GetUsingStatementString(usings));
+
+                if (!existing.Any())
+                {
+                    WriteLines(2);
+                }
+            }
+            finally
+            {
+                _pendingIndent = oldPendingIndent;
+                Indent = oldIndent;
             }
 
             return true;
@@ -762,18 +774,30 @@ namespace EditorServicesCommandSuite.CodeGeneration
 
         internal void WriteUsingStatement(string name, UsingStatementKind kind)
         {
-            char[] kindSymbol = kind switch
+            var oldPendingIndent = _pendingIndent;
+            var oldIndent = Indent;
+            try
             {
-                UsingStatementKind.Assembly => Symbols.Assembly,
-                UsingStatementKind.Module => Symbols.Module,
-                UsingStatementKind.Namespace => Symbols.Namespace,
-                _ => throw new InvalidOperationException(),
-            };
+                _pendingIndent = null;
+                Indent = 0;
+                char[] kindSymbol = kind switch
+                {
+                    UsingStatementKind.Assembly => Symbols.Assembly,
+                    UsingStatementKind.Module => Symbols.Module,
+                    UsingStatementKind.Namespace => Symbols.Namespace,
+                    _ => throw new InvalidOperationException(),
+                };
 
-            Write(Using);
-            Write(Space);
-            Write(kindSymbol);
-            Write(name);
+                Write(Using);
+                Write(Space);
+                Write(kindSymbol);
+                Write(name);
+            }
+            finally
+            {
+                _pendingIndent = oldPendingIndent;
+                Indent = oldIndent;
+            }
         }
 
         internal Task RegisterWorkspaceChangeAsync(DocumentContextBase context)

--- a/src/EditorServicesCommandSuite/CodeGeneration/Refactors/SuppressAnalyzerMessageRefactor.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/Refactors/SuppressAnalyzerMessageRefactor.cs
@@ -125,6 +125,7 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                 if (!_statementAcceptsAttributes)
                 {
                     WriteToParamBlock(Markers);
+                    Writer.CreateDocumentEdits();
                     return Writer.Edits;
                 }
 
@@ -140,9 +141,11 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                     else
                     {
                         WriteToStatement(group);
+                        Writer.WriteIndentIfPending();
                     }
                 }
 
+                Writer.CreateDocumentEdits();
                 return Writer.Edits;
             }
 
@@ -181,6 +184,7 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                 {
                     Writer.SetPosition(sbAst.ParamBlock);
                     WriteMarkers(markers);
+                    Writer.WriteIndentIfPending();
                     return;
                 }
 
@@ -201,7 +205,7 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                     return;
                 }
 
-                bool foundToken = Context.Token
+                bool foundToken = Context.Token.List.First
                     .FindNext()
                     .ContainingStartOf(sbAst)
                     .TryGetResult(out TokenNode entryToken);
@@ -276,8 +280,8 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                     return false;
                 }
 
-                Token tokenAtStatementStart = Context.Token
-                    .FindNext()
+                Token tokenAtStatementStart = Context.Token.List.First
+                    .FindNextOrSelf()
                     .ContainingStartOf(_parentStatementAst)
                     .GetResult()
                     .Value;

--- a/src/EditorServicesCommandSuite/CodeGeneration/Refactors/SuppressAnalyzerMessageRefactor.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/Refactors/SuppressAnalyzerMessageRefactor.cs
@@ -81,7 +81,9 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                 title: string.Format(
                     CultureInfo.CurrentCulture,
                     sourceAction.Title,
-                    marker.RuleSuppressionId));
+                    string.IsNullOrEmpty(marker.RuleSuppressionId)
+                        ? marker.RuleName
+                        : marker.RuleSuppressionId));
         }
 
         private async Task<IEnumerable<DiagnosticMarker>> GetMarkersAsync(DocumentContextBase request)
@@ -204,7 +206,7 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                     .ContainingStartOf(sbAst)
                     .TryGetResult(out TokenNode entryToken);
 
-                if (foundToken)
+                if (!foundToken)
                 {
                     Writer.SetPosition(sbAst);
                 }
@@ -257,7 +259,8 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                     Writer.WriteStringExpression(
                         StringConstantType.SingleQuoted,
                         marker.RuleName);
-                    Writer.Write(Symbols.Comma + Symbols.Space);
+                    Writer.Write(Symbols.Comma);
+                    Writer.Write(Symbols.Space);
                     Writer.WriteStringExpression(
                         StringConstantType.SingleQuoted,
                         marker.RuleSuppressionId);

--- a/tools/AssertRequiredModule.ps1
+++ b/tools/AssertRequiredModule.ps1
@@ -28,6 +28,12 @@ end {
     # TODO: Install required versions into the tools folder
     try {
         Import-Module @importModuleSplat -Force
+    } catch [System.IO.FileLoadException] {
+        # Hope this is the FileList manifest bug and move on if the module
+        # seems like it loaded.
+        if (-not (Get-Module $Name -ErrorAction Ignore)) {
+            throw $PSItem
+        }
     } catch [System.IO.FileNotFoundException] {
         Install-Module @importModuleSplat -Force:$Force.IsPresent -Scope $Scope
         Import-Module @importModuleSplat -Force


### PR DESCRIPTION
- Fix module import error in PSES stable when running in PowerShell 7
- The splat refactor is now significantly more reliable in it's placement of the variable assignment
- Fixed a whole lot of problems with the suppress analyzer refactor
- Update module version to 1.0.0-beta1