### PR TITLE
1.0.0-beta2

### DIFF
--- a/module/EditorServicesCommandSuite.psd1
+++ b/module/EditorServicesCommandSuite.psd1
@@ -92,7 +92,7 @@ PrivateData = @{
 '@
 
         # Prerelease string of this module
-        Prerelease = 'beta1'
+        Prerelease = 'beta2'
 
     } # End of PSData hashtable
 

--- a/src/EditorServicesCommandSuite.EditorServices/EditorServicesCommandSuite.EditorServices.csproj
+++ b/src/EditorServicesCommandSuite.EditorServices/EditorServicesCommandSuite.EditorServices.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\EditorServicesCommandSuite.Common.props" />
   <ItemGroup>
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.16.0" PrivateAssets="all" />
     <ProjectReference Include="..\EditorServicesCommandSuite\EditorServicesCommandSuite.csproj" />
     <Reference Include="Microsoft.PowerShell.EditorServices">
       <HintPath>..\..\lib\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/EditorServicesCommandSuite.PSReadLine/EditorServicesCommandSuite.PSReadLine.csproj
+++ b/src/EditorServicesCommandSuite.PSReadLine/EditorServicesCommandSuite.PSReadLine.csproj
@@ -4,6 +4,7 @@
     <ProjectReference Include="..\EditorServicesCommandSuite\EditorServicesCommandSuite.csproj" />
     <Reference Include="Microsoft.PowerShell.PSReadLine2">
       <HintPath>..\..\lib\PSReadLine\Microsoft.PowerShell.PSReadLine2.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/EditorServicesCommandSuite/CodeGeneration/Refactors/CommandSplatRefactor.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/Refactors/CommandSplatRefactor.cs
@@ -64,6 +64,17 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
 
         private CodeAction SplatMandatoryParametersCodeAction => SupportedActions[2];
 
+        public override async Task Invoke(DocumentContextBase context)
+        {
+            if (!context.Ast.TryFindParent(maxDepth: 3, out CommandAst command))
+            {
+                return;
+            }
+
+            await SplatCommandAsync(context, command, AdditionalParameterTypes.None, UI)
+                .ConfigureAwait(false);
+        }
+
         public override async Task ComputeCodeActions(DocumentContextBase context)
         {
             if (!context.Ast.TryFindParent(maxDepth: 3, out CommandAst command))

--- a/src/EditorServicesCommandSuite/CodeGeneration/Refactors/CommandSplatRefactor.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/Refactors/CommandSplatRefactor.cs
@@ -71,7 +71,9 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                 return;
             }
 
-            await SplatCommandAsync(context, command, AdditionalParameterTypes.None, UI)
+            await ProcessActionForInvoke(
+                context,
+                CreateCodeAction(command, AdditionalParameterTypes.None))
                 .ConfigureAwait(false);
         }
 

--- a/src/EditorServicesCommandSuite/EditorServicesCommandSuite.csproj
+++ b/src/EditorServicesCommandSuite/EditorServicesCommandSuite.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Buffers" Version="4.4.0" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.15.0" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.16.0" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/tools/AssertPSES.ps1
+++ b/tools/AssertPSES.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [ValidateNotNull()]
-    [string] $RequiredVersion = '2.0.0-preview.9'
+    [string] $RequiredVersion = '2.1.0'
 )
 begin {
     Add-Type -AssemblyName System.IO.Compression


### PR DESCRIPTION
- Update dependencies to fix binary breaking change
- Add default action to `CommandSplatRefactor` so it can work correctly when bound to a keyboard shortcut.
