### PR TITLE
ConvertTo-SplatExpression - new parameter to choose variable name casing

### DIFF
--- a/docs/en-US/ConvertTo-SplatExpression.md
+++ b/docs/en-US/ConvertTo-SplatExpression.md
@@ -13,7 +13,7 @@ Convert a command expression to use splatting.
 ## SYNTAX
 
 ```powershell
-ConvertTo-SplatExpression [[-Ast] <Ast>] [[-VariableName] <String>]
+ConvertTo-SplatExpression [[-Ast] <Ast>] [[-VariableName] <String>] [[-VariableCase] <string>]
 ```
 
 ## DESCRIPTION
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 
 ### -VariableName
 
-Specifies the Varabile name to use for the splat hashtable variable.
+Specifies the variable name to use for the splat hashtable variable.
 
 ```yaml
 Type: String
@@ -72,6 +72,22 @@ Aliases:
 Required: False
 Position: 2
 Default value: none
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VariableCase
+
+Specifies the casing for the variable name used for the splat hashtable variable. Choices are: `camelCase` (lowercase the first letter of the variable), `PascalCase` (upper case the first letter of the variable), or `Unmodified` (do not change the casing; use the same casing as the command being used to create the splat).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: camelCase
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/Public/ConvertTo-SplatExpression.ps1
+++ b/module/Public/ConvertTo-SplatExpression.ps1
@@ -11,9 +11,13 @@ function ConvertTo-SplatExpression {
     param(
         [System.Management.Automation.Language.Ast]
         $Ast,
-        
+
         [String]
-        $VariableName
+        $VariableName,
+
+        [ValidateSet('camelCase', 'PascalCase', 'Unmodified')]
+        [String]
+        $VariableCase = 'camelCase'
     )
     begin {
         function ConvertFromExpressionAst($expression) {
@@ -67,12 +71,32 @@ function ConvertTo-SplatExpression {
         }
 
         if (-not $VariableName) {
-            # Remove the hypen, change to camelCase and add 'Splat'
-            $variableName = [regex]::Replace(
-                ($commandName.Extent.Text -replace '-'),
-                '^[A-Z]',
-                { $args[0].Value.ToLower() }) +
-                'Splat'
+            switch ($VariableCase) {
+                'camelCase' {
+                    # Remove the hyphen, change to pascalCase, and add 'Splat
+                    $variableName = [regex]::Replace(
+                        ($commandName.Extent.Text -replace '-'),
+                        '^[A-Z]',
+                        { $args[0].Value.ToLower() }) +
+                        'Splat'
+                }
+                'PascalCase' {
+                    # Remove the hyphen, change to PascalCase, and add 'Splat'
+                    $variableName = [regex]::Replace(
+                        ($commandName.Extent.Text -replace '-'),
+                        '^[A-Z]',
+                        { $args[0].Value.ToUpper() }) +
+                        'Splat'
+                }
+                'Unmodified' {
+                    # Remove the hyphen, don't change case, and add 'Splat'
+                    $variableName = [regex]::Replace(
+                        ($commandName.Extent.Text -replace '-'),
+                        '^[A-Z]',
+                        { $args[0].Value }) +
+                        'Splat'
+                }
+            }
         }
 
         $sb = [System.Text.StringBuilder]::


### PR DESCRIPTION
Please see #58

This pull request adds a new parameter, ` VariableCase`, to `ConvertTo-SplatExpression` which allows the user to choose how the function capitalizes the first letter of the variable name it creates.

This parameter accepts one of three values from a ValidateSet:

1. `camelCase` - Sets the first letter of the variable to lowercase (This is the default to match current behavior).
1. `PascalCase` - Sets the first letter of the variable to uppercase.
1. `Unmodified` - Does not change the casing and uses the same casing as the command being used to create the splat.