### PR TITLE
Update OmniSharp and some fixes

### DIFF
--- a/EditorServicesCommandSuite.build.ps1
+++ b/EditorServicesCommandSuite.build.ps1
@@ -181,7 +181,7 @@ task DoTest {
 
         InvokeWithPSModulePath {
             & $dotnet test `
-                --framework netcoreapp2.0 `
+                --framework netcoreapp3.1 `
                 --configuration Test `
                 --logger "trx;LogFileName=$PSScriptRoot/TestResults/results.trx" `
                 -nologo

--- a/module/EditorServicesCommandSuite.psd1
+++ b/module/EditorServicesCommandSuite.psd1
@@ -92,7 +92,7 @@ PrivateData = @{
 '@
 
         # Prerelease string of this module
-        Prerelease = 'beta3'
+        Prerelease = 'beta4'
 
     } # End of PSData hashtable
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/EditorServicesCommandSuite.Common.props
+++ b/src/EditorServicesCommandSuite.Common.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\EditorServicesCommandSuite\stylecop.json" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" PrivateAssets="All" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/EditorServicesCommandSuite.Common.props
+++ b/src/EditorServicesCommandSuite.Common.props
@@ -6,7 +6,7 @@
     <Configurations>Debug;Release;Test</Configurations>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <LangVersion>preview</LangVersion>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
@@ -15,10 +15,10 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-preview-04" PrivateAssets="All" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="All" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.0.2" PrivateAssets="All" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.6" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Test' ">
     <DefineConstants>TEST</DefineConstants>

--- a/src/EditorServicesCommandSuite.EditorServices/DocumentService.cs
+++ b/src/EditorServicesCommandSuite.EditorServices/DocumentService.cs
@@ -75,7 +75,7 @@ namespace EditorServicesCommandSuite.EditorServices
                     textEdits.Add(textEdit);
                 }
 
-                var versionedIdentifier = new VersionedTextDocumentIdentifier
+                var versionedIdentifier = new OptionalVersionedTextDocumentIdentifier
                 {
                     Uri = DocumentUri.From(editGroup.Key ?? context.Uri),
                     Version = default,

--- a/src/EditorServicesCommandSuite.EditorServices/EditorServicesCommandSuite.EditorServices.csproj
+++ b/src/EditorServicesCommandSuite.EditorServices/EditorServicesCommandSuite.EditorServices.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\EditorServicesCommandSuite.Common.props" />
   <ItemGroup>
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" PrivateAssets="all" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.2" PrivateAssets="all" />
     <ProjectReference Include="..\EditorServicesCommandSuite\EditorServicesCommandSuite.csproj" />
     <Reference Include="Microsoft.PowerShell.EditorServices">
       <HintPath>..\..\lib\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.dll</HintPath>

--- a/src/EditorServicesCommandSuite.EditorServices/EditorServicesCommandSuite.EditorServices.csproj
+++ b/src/EditorServicesCommandSuite.EditorServices/EditorServicesCommandSuite.EditorServices.csproj
@@ -1,13 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\EditorServicesCommandSuite.Common.props" />
-  <PropertyGroup>
-    <RestoreAdditionalProjectSources>
-      $(RestoreAdditionalProjectSources)
-      https://www.myget.org/F/omnisharp/api/v3/index.json
-    </RestoreAdditionalProjectSources>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.0-*" PrivateAssets="all" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" PrivateAssets="all" />
     <ProjectReference Include="..\EditorServicesCommandSuite\EditorServicesCommandSuite.csproj" />
     <Reference Include="Microsoft.PowerShell.EditorServices">
       <HintPath>..\..\lib\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.dll</HintPath>

--- a/src/EditorServicesCommandSuite/CodeGeneration/DocumentEditWriter.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/DocumentEditWriter.cs
@@ -94,7 +94,7 @@ namespace EditorServicesCommandSuite.CodeGeneration
             }
         }
 
-        internal static Encoding DefaultEncoding { get; set; } = Encoding.ASCII;
+        internal static Encoding DefaultEncoding { get; set; } = Encoding.Unicode;
 
         internal virtual IEnumerable<DocumentEdit> Edits
         {

--- a/src/EditorServicesCommandSuite/CodeGeneration/PowerShellScriptWriter.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/PowerShellScriptWriter.cs
@@ -699,6 +699,18 @@ namespace EditorServicesCommandSuite.CodeGeneration
 
             if (parameter.Value.ConstantValue is bool boolean)
             {
+                // Switch parameters lie sometimes, e.g. `-Verbose:$something.Value` will
+                // still report "ConstantValue: $true".
+                if (parameter.Value.Value is not null)
+                {
+                    string astString = parameter.Value.Value.ToString();
+                    if (!string.IsNullOrEmpty(astString))
+                    {
+                        Write(astString);
+                        return;
+                    }
+                }
+
                 Write(Dollar + boolean.ToString().ToLower());
                 return;
             }

--- a/src/EditorServicesCommandSuite/CodeGeneration/Refactors/CommandSplatRefactor.cs
+++ b/src/EditorServicesCommandSuite/CodeGeneration/Refactors/CommandSplatRefactor.cs
@@ -186,16 +186,16 @@ namespace EditorServicesCommandSuite.CodeGeneration.Refactors
                     unresolvedBinding = StaticParameterBinder.BindCommand(args.Command, resolve: false);
                 }
 
-                bool isBound = unresolvedBinding.BoundParameters.TryGetValue(
-                    bindingException.Key,
-                    out ParameterBindingResult unresolvedResult);
-
-                if (isBound)
+                if (unresolvedBinding.BoundParameters.TryGetValue(bindingException.Key, out ParameterBindingResult unresolvedResult))
                 {
-                    parameterList.Add(
-                        new Parameter(
-                            bindingException.Key,
-                            unresolvedResult));
+                    parameterList.Add(new Parameter(bindingException.Key, unresolvedResult));
+                    continue;
+                }
+
+                if (bindingException.Value.BindingException is ParameterBindingException pbe
+                    && unresolvedBinding.BoundParameters.TryGetValue(pbe.ParameterName, out unresolvedResult))
+                {
+                    parameterList.Add(new Parameter(pbe.ParameterName, unresolvedResult));
                 }
             }
 

--- a/src/EditorServicesCommandSuite/EditorServicesCommandSuite.csproj
+++ b/src/EditorServicesCommandSuite/EditorServicesCommandSuite.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" PrivateAssets="all" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.2" PrivateAssets="all" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
 </Project>

--- a/src/EditorServicesCommandSuite/EditorServicesCommandSuite.csproj
+++ b/src/EditorServicesCommandSuite/EditorServicesCommandSuite.csproj
@@ -1,16 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\EditorServicesCommandSuite.Common.props" />
-  <PropertyGroup>
-    <RestoreAdditionalProjectSources>
-      $(RestoreAdditionalProjectSources)
-      https://www.myget.org/F/omnisharp/api/v3/index.json
-    </RestoreAdditionalProjectSources>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.0-*" PrivateAssets="all" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
   </ItemGroup>
 </Project>

--- a/test/EditorServicesCommandSuite.Tests/CommandSplatTests.cs
+++ b/test/EditorServicesCommandSuite.Tests/CommandSplatTests.cs
@@ -91,7 +91,8 @@ namespace EditorServicesCommandSuite.Tests
                     .Lines("    From = $mandatoryStringFrom")
                     .Lines("    SmtpServer = $stringSmtpServer")
                     .Lines("    Priority = $mailPriorityPriority")
-                    .Lines("    Subject = $mandatoryStringSubject")
+                    .Lines("    ReplyTo = $stringArrayReplyTo")
+                    .Lines("    Subject = $stringSubject")
                     .Lines("    To = $mandatoryStringArrayTo")
                     .Lines("    Credential = $pSCredentialCredential")
                     .Lines("    UseSsl = $switchParameterUseSsl")
@@ -119,7 +120,8 @@ namespace EditorServicesCommandSuite.Tests
                     .Lines("    DeliveryNotificationOption = $deliveryNotificationOptionsDeliveryNotificationOption")
                     .Lines("    SmtpServer = $stringSmtpServer")
                     .Lines("    Priority = $mailPriorityPriority")
-                    .Lines("    Subject = $mandatoryStringSubject")
+                    .Lines("    ReplyTo = $stringArrayReplyTo")
+                    .Lines("    Subject = $stringSubject")
                     .Lines("    To = $mandatoryStringArrayTo")
                     .Lines("    Credential = $pSCredentialCredential")
                     .Lines("    UseSsl = $switchParameterUseSsl")
@@ -264,7 +266,6 @@ namespace EditorServicesCommandSuite.Tests
                 TestBuilder.Create()
                     .Lines("$splat = @{")
                     .Lines("    From = $mandatoryStringFrom")
-                    .Lines("    Subject = $mandatoryStringSubject")
                     .Lines("    To = $mandatoryStringArrayTo")
                     .Lines("}")
                     .Texts("Send-MailMessage @splat"),
@@ -280,7 +281,6 @@ namespace EditorServicesCommandSuite.Tests
                 TestBuilder.Create()
                     .Lines("$splat = @{")
                     .Lines("    From = 'someone@someplace.com'")
-                    .Lines("    Subject = $mandatoryStringSubject")
                     .Lines("    To = $mandatoryStringArrayTo")
                     .Lines("}")
                     .Texts("Send-MailMessage @splat"),
@@ -383,7 +383,6 @@ namespace EditorServicesCommandSuite.Tests
                 TestBuilder.Create()
                     .Lines("$splat = @{")
                     .Lines("    From = $from")
-                    .Lines("    Subject = $subject")
                     .Lines("    To = $to")
                     .Lines("}")
                     .Texts("Send-MailMessage @splat"),

--- a/test/EditorServicesCommandSuite.Tests/EditorServicesCommandSuite.Tests.csproj
+++ b/test/EditorServicesCommandSuite.Tests/EditorServicesCommandSuite.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.0.2" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.6" />
     <ProjectReference Include="..\..\src\EditorServicesCommandSuite\EditorServicesCommandSuite.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/tools/AssertPSES.ps1
+++ b/tools/AssertPSES.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [ValidateNotNull()]
-    [string] $RequiredVersion = '2.2.0'
+    [string] $RequiredVersion = '2.3.0'
 )
 begin {
     Add-Type -AssemblyName System.IO.Compression

--- a/tools/AssertPSES.ps1
+++ b/tools/AssertPSES.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [ValidateNotNull()]
-    [string] $RequiredVersion = '2.3.0'
+    [string] $RequiredVersion = '2.4.5'
 )
 begin {
     Add-Type -AssemblyName System.IO.Compression


### PR DESCRIPTION
- Updated OmniSharp (Fixes #66, #65 #64)
- Worked around psuedo parameter binder bug that causes switch parameters to report a constant bool value regardless of explicit argument (Fixes #56)
- Worked around psuedo parameter binder bug that causes invalid binding exceptions I didn't account for (Fixes #62)
- Changed encoding of the document edit writer to unicode to fix a bug reported on discord where unicode characters were getting mangled (why am I using a byte stream instead of an `List<char>`? Because I had no idea what I was doing two years ago 🙃 )
- Updated manifest to beta4